### PR TITLE
fix: updates references to BlueprintMetadataSpec fields

### DIFF
--- a/cli/bpconsume/jumpstartsolutions/cmd.go
+++ b/cli/bpconsume/jumpstartsolutions/cmd.go
@@ -108,7 +108,7 @@ func generateTextprotoFile(bpObj, bpDpObj *bpmetadata.BlueprintMetadata) error {
 		return err
 	}
 
-	solutionName := bpObj.Spec.BlueprintInfo.Title
+	solutionName := bpObj.Spec.Info.Title
 	solutionId := strings.ReplaceAll(strings.ToLower(solutionName), " ", "_")
 	fileName := solutionId + ".textproto"
 	err = os.WriteFile(fileName, b, 0644)

--- a/cli/bpconsume/jumpstartsolutions/soyWriter.go
+++ b/cli/bpconsume/jumpstartsolutions/soyWriter.go
@@ -32,14 +32,14 @@ func createDiagramDescription(steps []string, solutionName string) string {
 }
 
 func generateSoy(bpObj *bpmetadata.BlueprintMetadata) error {
-	solutionName := bpObj.Spec.BlueprintInfo.Title
+	solutionName := bpObj.Spec.Info.Title
 	solutionId := generateSolutionId(solutionName)
-	solutionTitle := bpObj.Spec.BlueprintInfo.Title
-	solutionSummary := bpObj.Spec.BlueprintInfo.Description.Tagline
-	solutionDescription := bpObj.Spec.BlueprintInfo.Description.Detailed
-	solutionDiagramSteps := bpObj.Spec.BlueprintInfo.Description.Architecture
+	solutionTitle := bpObj.Spec.Info.Title
+	solutionSummary := bpObj.Spec.Info.Description.Tagline
+	solutionDescription := bpObj.Spec.Info.Description.Detailed
+	solutionDiagramSteps := bpObj.Spec.Info.Description.Architecture
 	if len(solutionDiagramSteps) == 0 {
-		solutionDiagramSteps = bpObj.Spec.BlueprintContent.Architecture.Description
+		solutionDiagramSteps = bpObj.Spec.Content.Architecture.Description
 	}
 	solutionDiagramDescription := createDiagramDescription(solutionDiagramSteps, solutionName)
 


### PR DESCRIPTION
Prior to v1.0.0 BlueprintMetadataSpec had anonymous fields and bpconsume will still referring to them. This change addresses that and updates the references to concrete fields.